### PR TITLE
Improve clang-tidy job

### DIFF
--- a/.github/workflows/server-workflow.yml
+++ b/.github/workflows/server-workflow.yml
@@ -228,7 +228,7 @@ jobs:
       - name: Export report
         uses: actions/upload-artifact@v2
         with:
-          name: clang-tidy-reports
+          name: clang-tidy-reports-{{ matrix.qt }}
           path: clang-tidy-reports
         if: steps.reports-number.outputs.count != 0
 


### PR DESCRIPTION
- Build project in clang-tidy job to generate moc files
- Use different names for clang-tidy artifacts
